### PR TITLE
Change Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /src/
 COPY go.mod go.sum main.go ./
 RUN apk -U add binutils && CGO_ENABLED=0 go build -o prometheus-logstash-exporter && strip prometheus-logstash-exporter
 
-FROM alpine
+FROM scratch
 WORKDIR /
 COPY --from=builder /src/prometheus-logstash-exporter /
 EXPOSE 9304


### PR DESCRIPTION
- copy [from origin](https://github.com/alxrem/prometheus-logstash-exporter/pull/26)

In Alpine image exist library, which is vulnerable and LogstashExporter dont need this library.
In Scratch image this library dont exist.